### PR TITLE
Add support for multiple targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Enhanced Annotations #
 
 *	Authors: George Kerscher, Noelia Ruiz Martínez
-* [download stable version][1] (compatible with NVDA 2022.1 and beyond)
+* [download stable version][1] (compatible with NVDA 2023.1 and beyond)
 
 In the DAISY Consortium, best practices are developed for publishers and authors for providing extended (long) descriptions.
 
@@ -20,9 +20,14 @@ This add-on provides both features, in support of this [issue opened in NVDA's r
 ## Commands ##
 
 * NVDA+alt+d: moves the cursor to the element identified with aria-details.
-* NVDA+alt+shift+d: moves the cursor to the original element, for example, an image with furter details like a long description.
+* NVDA+alt+shift+d: moves the cursor to the original element, for example, an image with furter details like a long description. If NVDA+alt+d has been pressed several times to move to related annotations, it'll be possible to go back to each origin.
 
 The above commands can be modified from NVDA's menu, Preferences submenu, Input gestures dialog, Browse mode category.
+
+## Changes for 2.0 ##
+
+* Added ability to move back through multiple annotation origins.
+* Requires NVDA 2023.1 or later.
 
 [1]: https://addons.nvda-project.org/files/get.php?file=enhancedannotations
 

--- a/addon/globalPlugins/enhancedAnnotations/__init__.py
+++ b/addon/globalPlugins/enhancedAnnotations/__init__.py
@@ -2,23 +2,29 @@
 
 # enhancedAnnotations: add ability to move to additional details and go back to original object
 # https://github.com/nvaccess/nvda/issues/13940
-# Copyright (C) 2022 Noelia Ruiz Martínez
+# Copyright (C) 2022-2023 Noelia Ruiz Martínez, NV Access
+# Implementation of PR: https://github.com/nvaccess/nvda/pull/14389 
 # Released under GPL 2
 
 from typing import Callable
 
 import api
+import config
 import ui
 import speech
+import textInfos
 import inputCore
 import globalPluginHandler
+from annotation import (
+	_AnnotationNavigation,
+	_AnnotationNavigationNode,
+)
 from logHandler import log
 from browseMode import BrowseModeDocumentTreeInterceptor
 from controlTypes import OutputReason
+from NVDAObjects import NVDAObject
 from scriptHandler import script
 import addonHandler
-
-from .skipTranslation import translate
 
 addonHandler.initTranslation()
 
@@ -29,57 +35,124 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 
 	scriptCategory = inputCore.SCRCAT_BROWSEMODE
 
-	def __init__(self):
-		super().__init__()
-		self._lastObjWithDetails = None
-
-	def terminate(self):
-		self._lastObjWithDetails = None
-
-	@script(
-		# Translators: message presented in input help mode.
-		description=_("Navigates to the details of the current position in browse mode"),
-		gesture="kb:NVDA+alt+d"
-	)
-	def script_moveToRelatedDetails(self, gesture):
-		focus = api.getFocusObject()
-		treeInterceptor = focus.treeInterceptor
-		if not isinstance(treeInterceptor, BrowseModeDocumentTreeInterceptor) or treeInterceptor.passThrough:
-			return
-		curObj = treeInterceptor.currentNVDAObject
-		if curObj.hasDetails:
-			relatedDetails = curObj.detailsRelations
-		else:
-			# Message translated in NVDA's core.
-			ui.message(translate("No additional details"))
-			return
-		for target in relatedDetails:
-			info = treeInterceptor.makeTextInfo(target)
-			info.collapse()
-			treeInterceptor._set_selection(info, reason=OutputReason.QUICKNAV)
-			speech.speakObject(treeInterceptor.currentNVDAObject, reason=OutputReason.QUICKNAV)
-			self._lastObjWithDetails = curObj
-			return
-
-	@script(
-		# Translators: message presented in input help mode.
-		description=_("After navigating to additional details, moves back to the original position in browse mode"),
-		gesture="kb:NVDA+shift+alt+d"
-	)
-	def script_moveBackToObjWithDetails(self, gesture):
-		focus = api.getFocusObject()
-		treeInterceptor = focus.treeInterceptor
-		if not isinstance(treeInterceptor, BrowseModeDocumentTreeInterceptor) or treeInterceptor.passThrough:
-			return
-		if self._lastObjWithDetails is None:
-			# Translators: message presented when there's no original object to go back from additional details.
-			ui.message(_("No element with additional details to go back"))
-			return
+	def _getNvdaObjWithAnnotationUnderCaret(self) -> Optional[NVDAObject]:
+		"""If it has an annotation, get the NVDA object for the single character under the caret or the object
+		with system focus.
+		@note: It is tempting to try to report any annotation details that exists in the range formed by prior
+			and current location. This would be a new paradigm in NVDA, and may feel natural when moving by line
+			to be able to more quickly have the 'details' reported. However, there may be more than one 'details
+			relation' in that range, and we don't yet have a way for the user to select which one to report.
+			For now, we minimise this risk by only reporting details at the current location.
+		"""
 		try:
-			info = treeInterceptor.makeTextInfo(self._lastObjWithDetails)
-			info.collapse()
-			treeInterceptor._set_selection(info, reason=OutputReason.QUICKNAV)
-			speech.speakObject(treeInterceptor.currentNVDAObject, reason=OutputReason.QUICKNAV)
-		except LookupError as e:
-			log.debugWarning("enhancedAnnotations add-on: error moving to object with details", exc_info=True)
-			raise e
+			# Common cases use Caret Position: vbuf available or object supports text range
+			# Eg editable text, or regular web content
+			# Firefox and Chromium support this even in a button within a role=application.
+			caret: textInfos.TextInfo = api.getCaretPosition()
+		except RuntimeError:
+			log.debugWarning("Unable to get the caret position.", exc_info=True)
+			return None
+		caret.expand(textInfos.UNIT_CHARACTER)
+		objAtStart: NVDAObject = caret.NVDAObjectAtStart
+		_isDebugLogCatEnabled = bool(config.conf["debugLog"]["annotations"])
+		if _isDebugLogCatEnabled:
+			log.debug(f"Trying with nvdaObject : {objAtStart}")
+
+		if objAtStart.detailsSummary:
+			log.debug(f"NVDAObjectAtStart of caret has details: {objAtStart.detailsSummary}")
+			return objAtStart
+		elif api.getFocusObject():
+			# If fetching from the caret position fails, try via the focus object
+			# This case is to support where there is no virtual buffer or text interface and a caret position can
+			# not be fetched.
+			# There may still be an object with focus that has details.
+			# There isn't a known test case for this, however there isn't a known downside to attempt this.
+			focus = api.getFocusObject()
+			if _isDebugLogCatEnabled:
+				log.debug(f"Trying focus object: {focus}")
+
+			if focus.detailsSummary:
+				if _isDebugLogCatEnabled:
+					log.debug("focus object has details, able to proceed")
+				return focus
+
+		if _isDebugLogCatEnabled:
+			log.debug("no details annotation found")
+		return None
+
+	_annotationNav = AnnotationNavigation()
+
+	@script(
+		gesture="kb:NVDA+alt+d",
+		description=_(
+			# Translators: the description for the reportDetailsSummary script.
+			"Go to annotation details under the system caret."
+		)
+	)
+	def script_goToAnnotation(self, gesture):
+		"""Go to the annotation details for the single character under the caret or the object with
+		system focus.
+		@note: See related script_reportDetailsSummary
+		"""
+		log.debug("Go to annotation details at current location.")
+		objWithAnnotation = self._getNvdaObjWithAnnotationUnderCaret()
+		if not objWithAnnotation:
+			# Translators: message given when there is no annotation details for the reportDetailsSummary script.
+			ui.message(_("No annotation present"))
+			return
+
+		if (
+			self._annotationNav.lastReported
+			and objWithAnnotation == self._annotationNav.lastReported.origin
+			and None is not self._annotationNav.lastReported.indexOfLastReportedSummary
+		):
+			# This origin was the last
+			targetIndex = self._annotationNav.lastReported.indexOfLastReportedSummary
+			target = list(objWithAnnotation.annotations.targets)[targetIndex]
+		else:
+			target = next(iter(objWithAnnotation.annotations.targets))
+		# Translators: message given when navigating to annotation target.
+		ui.message("Navigating to target")
+		self._moveToObject(target.targetObject)
+		self._annotationNav.priorOrigins.append(objWithAnnotation)
+		return
+
+	def _moveToObject(self, toObject: "NVDAObject"):
+		focus = api.getFocusObject()
+		treeInterceptor = focus.treeInterceptor
+		if not isinstance(treeInterceptor, BrowseModeDocumentTreeInterceptor) or treeInterceptor.passThrough:
+			return
+		info = treeInterceptor.makeTextInfo(toObject)
+		forSelect = info.copy()
+		forSelect.collapse()
+		treeInterceptor._set_selection(forSelect, reason=OutputReason.QUICKNAV)
+		self._reportInfoAfterMove(info)
+
+	def _reportInfoAfterMove(self, info: "textInfos.TextInfo"):
+
+		# See impl of browseMode.TextInfoQuickNavItem.report sometimes readUnit is provided:
+		# It originates from using textInfos.UNIT_LINE for:
+		# Table, list, edit, frame, notLinkBlock, landmark
+		# See "Add quick navigation scripts" in source/browseMode.py:646
+		speech.speakTextInfo(info, reason=OutputReason.QUICKNAV)
+
+	@script(
+		gesture="kb:NVDA+alt+shift+d",
+		description=_(
+			# Translators: the description for the script_popAnnotationStack script.
+			"Return to annotation subject"
+		)
+	)
+	def script_popAnnotationStack(self, gesture):
+		"""Go to the annotation details for the single character under the caret or the object with
+		system focus.
+		@note: See related script_reportDetailsSummary
+		"""
+		log.debug("Return to annotation parent.")
+		if not self._annotationNav.priorOrigins:
+			# Translators: message given when there is no annotation details for the reportDetailsSummary script.
+			ui.message(_("No annotation subject present"))
+			return
+		annotationParent = self._annotationNav.priorOrigins.pop()
+		self._moveToObject(annotationParent)
+		return

--- a/addon/globalPlugins/enhancedAnnotations/__init__.py
+++ b/addon/globalPlugins/enhancedAnnotations/__init__.py
@@ -15,14 +15,16 @@ import speech
 import textInfos
 import inputCore
 import globalPluginHandler
-from annotation import _AnnotationNavigation
-
+from globalCommands import commands
 from logHandler import log
 from browseMode import BrowseModeDocumentTreeInterceptor
 from controlTypes import OutputReason
 from NVDAObjects import NVDAObject
 from scriptHandler import script
 import addonHandler
+
+
+from .skipTranslation import translate
 
 addonHandler.initTranslation()
 
@@ -32,53 +34,6 @@ _: Callable[[str], str]
 class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 
 	scriptCategory = inputCore.SCRCAT_BROWSEMODE
-
-	def _getNvdaObjWithAnnotationUnderCaret(self) -> Optional[NVDAObject]:
-		"""If it has an annotation, get the NVDA object for the single character under the caret or the object
-		with system focus.
-		@note: It is tempting to try to report any annotation details that exists in the range formed by prior
-			and current location. This would be a new paradigm in NVDA, and may feel natural when moving by line
-			to be able to more quickly have the 'details' reported. However, there may be more than one 'details
-			relation' in that range, and we don't yet have a way for the user to select which one to report.
-			For now, we minimise this risk by only reporting details at the current location.
-		"""
-		try:
-			# Common cases use Caret Position: vbuf available or object supports text range
-			# Eg editable text, or regular web content
-			# Firefox and Chromium support this even in a button within a role=application.
-			caret: textInfos.TextInfo = api.getCaretPosition()
-		except RuntimeError:
-			log.debugWarning("Unable to get the caret position.", exc_info=True)
-			return None
-		caret.expand(textInfos.UNIT_CHARACTER)
-		objAtStart: NVDAObject = caret.NVDAObjectAtStart
-		_isDebugLogCatEnabled = bool(config.conf["debugLog"]["annotations"])
-		if _isDebugLogCatEnabled:
-			log.debug(f"Trying with nvdaObject : {objAtStart}")
-
-		if objAtStart.detailsSummary:
-			log.debug(f"NVDAObjectAtStart of caret has details: {objAtStart.detailsSummary}")
-			return objAtStart
-		elif api.getFocusObject():
-			# If fetching from the caret position fails, try via the focus object
-			# This case is to support where there is no virtual buffer or text interface and a caret position can
-			# not be fetched.
-			# There may still be an object with focus that has details.
-			# There isn't a known test case for this, however there isn't a known downside to attempt this.
-			focus = api.getFocusObject()
-			if _isDebugLogCatEnabled:
-				log.debug(f"Trying focus object: {focus}")
-
-			if focus.detailsSummary:
-				if _isDebugLogCatEnabled:
-					log.debug("focus object has details, able to proceed")
-				return focus
-
-		if _isDebugLogCatEnabled:
-			log.debug("no details annotation found")
-		return None
-
-	_annotationNav = _AnnotationNavigation()
 
 	@script(
 		gesture="kb:NVDA+alt+d",
@@ -93,26 +48,24 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 		@note: See related script_reportDetailsSummary
 		"""
 		log.debug("Go to annotation details at current location.")
-		objWithAnnotation = self._getNvdaObjWithAnnotationUnderCaret()
+		objWithAnnotation = commands._getNvdaObjWithAnnotationUnderCaret()
 		if not objWithAnnotation:
 			# Translators: message given when there is no annotation details for the reportDetailsSummary script.
-			ui.message(_("No annotation present"))
+			ui.message(translate("No additional details"))
 			return
 
 		if (
-			self._annotationNav.lastReported
-			and objWithAnnotation == self._annotationNav.lastReported.origin
-			and None is not self._annotationNav.lastReported.indexOfLastReportedSummary
+			commands._annotationNav.lastReported
+			and objWithAnnotation == commands._annotationNav.lastReported.origin
+			and None is not commands._annotationNav.lastReported.indexOfLastReportedSummary
 		):
 			# This origin was the last
-			targetIndex = self._annotationNav.lastReported.indexOfLastReportedSummary
+			targetIndex = commands._annotationNav.lastReported.indexOfLastReportedSummary
 			target = list(objWithAnnotation.annotations.targets)[targetIndex]
 		else:
 			target = next(iter(objWithAnnotation.annotations.targets))
-		# Translators: message given when navigating to annotation target.
-		ui.message("Navigating to target")
 		self._moveToObject(target.targetObject)
-		self._annotationNav.priorOrigins.append(objWithAnnotation)
+		commands._annotationNav.priorOrigins.append(objWithAnnotation)
 		return
 
 	def _moveToObject(self, toObject: "NVDAObject"):
@@ -142,15 +95,15 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 		)
 	)
 	def script_popAnnotationStack(self, gesture):
-		"""Go to the annotation details for the single character under the caret or the object with
+		"""Go to the annotation subject for the single character under the caret or the object with
 		system focus.
 		@note: See related script_reportDetailsSummary
 		"""
 		log.debug("Return to annotation parent.")
-		if not self._annotationNav.priorOrigins:
+		if not commands._annotationNav.priorOrigins:
 			# Translators: message given when there is no annotation details for the reportDetailsSummary script.
 			ui.message(_("No annotation subject present"))
 			return
-		annotationParent = self._annotationNav.priorOrigins.pop()
+		annotationParent = commands._annotationNav.priorOrigins.pop()
 		self._moveToObject(annotationParent)
 		return

--- a/addon/globalPlugins/enhancedAnnotations/__init__.py
+++ b/addon/globalPlugins/enhancedAnnotations/__init__.py
@@ -6,10 +6,9 @@
 # Implementation of PR: https://github.com/nvaccess/nvda/pull/14389
 # Released under GPL 2
 
-from typing import Callable, Optional
+from typing import Callable
 
 import api
-import config
 import ui
 import speech
 import textInfos
@@ -22,7 +21,6 @@ from controlTypes import OutputReason
 from NVDAObjects import NVDAObject
 from scriptHandler import script
 import addonHandler
-
 
 from .skipTranslation import translate
 

--- a/addon/globalPlugins/enhancedAnnotations/__init__.py
+++ b/addon/globalPlugins/enhancedAnnotations/__init__.py
@@ -3,7 +3,7 @@
 # enhancedAnnotations: add ability to move to additional details and go back to original object
 # https://github.com/nvaccess/nvda/issues/13940
 # Copyright (C) 2022-2023 Noelia Ruiz Martínez, NV Access
-# Implementation of PR: https://github.com/nvaccess/nvda/pull/14389 
+# Implementation of PR: https://github.com/nvaccess/nvda/pull/14389
 # Released under GPL 2
 
 from typing import Callable, Optional

--- a/addon/globalPlugins/enhancedAnnotations/__init__.py
+++ b/addon/globalPlugins/enhancedAnnotations/__init__.py
@@ -6,7 +6,7 @@
 # Implementation of PR: https://github.com/nvaccess/nvda/pull/14389 
 # Released under GPL 2
 
-from typing import Callable
+from typing import Callable, Optional
 
 import api
 import config
@@ -15,10 +15,8 @@ import speech
 import textInfos
 import inputCore
 import globalPluginHandler
-from annotation import (
-	_AnnotationNavigation,
-	_AnnotationNavigationNode,
-)
+from annotation import _AnnotationNavigation
+
 from logHandler import log
 from browseMode import BrowseModeDocumentTreeInterceptor
 from controlTypes import OutputReason
@@ -80,7 +78,7 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 			log.debug("no details annotation found")
 		return None
 
-	_annotationNav = AnnotationNavigation()
+	_annotationNav = _AnnotationNavigation()
 
 	@script(
 		gesture="kb:NVDA+alt+d",

--- a/buildVars.py
+++ b/buildVars.py
@@ -30,9 +30,9 @@ addon_info = {
 	# Documentation file name
 	"addon_docFileName": "readme.html",
 	# Minimum NVDA version supported (e.g. "2018.3")
-	"addon_minimumNVDAVersion": "2022.1",
+	"addon_minimumNVDAVersion": "2023.1",
 	# Last NVDA version supported/tested (e.g. "2018.4", ideally more recent than minimum version)
-	"addon_lastTestedNVDAVersion": "2022.4",
+	"addon_lastTestedNVDAVersion": "2023.1",
 	# Add-on update channel (default is stable or None)
 	"addon_updateChannel": None,
 }


### PR DESCRIPTION
## Link to issue number:
None
### Summary of the issue:
For now, the add-on allows navigation to a single target, but different targets maybe provided.
### Description of how this pull request fixes the issue:
Coded has been borrowed from nvaccess/nvda#14389, just with some minor changes like preserving browse mode category for scripts. NV Access has been added to copyright of the Python file, since this is an implementation of the above pull request created in NVDA's repo.
### Testing performed:
Some tests were done time ago, but this needs further testing.
### Known issues with pull request:
None
### Change log entry:
* Added ability to navigate to multiple targets.