### PR TITLE
Update last tested version to 2024.1

### DIFF
--- a/buildVars.py
+++ b/buildVars.py
@@ -32,7 +32,7 @@ addon_info = {
 	# Minimum NVDA version supported (e.g. "2018.3")
 	"addon_minimumNVDAVersion": "2023.1",
 	# Last NVDA version supported/tested (e.g. "2018.4", ideally more recent than minimum version)
-	"addon_lastTestedNVDAVersion": "2023.1",
+	"addon_lastTestedNVDAVersion": "2024.1",
 	# Add-on update channel (default is stable or None)
 	"addon_updateChannel": None,
 }


### PR DESCRIPTION
## Link to issue number:
None
### Summary of the issue:
NVDA 2024.1 breaks backward compatibility.
### Description of how this pull request fixes the issue:
Update last tested version to 2024.1.
### Testing performed:
Tested locally.
### Known issues with pull request:
None
### Change log entry:
None